### PR TITLE
Fix bit mask for fifo_level in fifo_status_get API

### DIFF
--- a/lsm6dsv16b_reg.c
+++ b/lsm6dsv16b_reg.c
@@ -5851,7 +5851,7 @@ int32_t lsm6dsv16b_fifo_status_get(const stmdev_ctx_t *ctx,
   val->fifo_full = status.fifo_full_ia;
   val->fifo_th = status.fifo_wtm_ia;
 
-  val->fifo_level = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8)) & 0x1FU;
+  val->fifo_level = (uint16_t)(buff[0] | ((uint16_t)buff[1] << 8)) & 0x1FFU;
 
   return ret;
 }


### PR DESCRIPTION
Fixes #2. The previous mask (0x1F) only covered 5 bits, causing the FIFO level reading to truncate. Updated the mask to cover the full 9 bits required by the hardware spec.